### PR TITLE
Add home-manager module and lib.mkNixvim function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,55 @@ Run the full configuration with all language support:
 nix run .#nvim-full
 ```
 
+### Home Manager Integration
+
+Add to your Home Manager configuration:
+
+```nix
+{
+  inputs.coldsteel-nixvim.url = "github:andoriyu/nixvim";
+  
+  outputs = { self, nixpkgs, home-manager, coldsteel-nixvim, ... }: {
+    homeConfigurations."username" = home-manager.lib.homeManagerConfiguration {
+      # ...
+      modules = [
+        coldsteel-nixvim.homeManagerModules.default
+        {
+          coldsteel.nixvim = {
+            enable = true;
+            defaultEditor = true;
+            
+            # Enable specific language support
+            go = true;
+            rust = true;
+            
+            # Or use a preset configuration
+            # preset = "full";  # Options: "none", "lite", "full", "custom"
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+### Using the Library Function
+
+You can also use the provided library function to create a custom configuration:
+
+```nix
+{
+  environment.systemPackages = [
+    (inputs.coldsteel-nixvim.lib.mkNixvim {
+      system = pkgs.system;
+      go = true;
+      rust = true;
+      none-ls = true;
+    })
+  ];
+}
+```
+
 ## Configuration Profiles
 
 ### Full Profile

--- a/README.md
+++ b/README.md
@@ -1,18 +1,157 @@
-# Nixvim template
+# Nixvim Configuration
 
-This template gives you a good starting point for configuring nixvim standalone.
+A customizable Neovim configuration using [nixvim](https://github.com/nix-community/nixvim), allowing you to manage your Neovim setup through Nix.
 
-## Configuring
+## Features
 
-To start configuring, just add or modify the nix files in `./config`.
-If you add a new configuration file, remember to add it to the
-[`config/default.nix`](./config/default.nix) file
+- **Modular Configuration**: Easily add or modify components
+- **Multiple Profiles**: Choose between full-featured or lightweight setups
+- **Language Support**: Preconfigured for Go, Rust, Terraform, Docker, and web development
+- **Docker Integration**: Run your configuration in containers
+- **Cachix Support**: Faster builds with pre-built binaries
+- **GitHub Actions**: Automated testing across platforms
 
-## Testing your new configuration
+## Quick Start
 
-To test your configuration simply run the following command
+Run the default (lite) configuration:
 
-```
+```bash
 nix run .
 ```
-# nixvim
+
+Run the full configuration with all language support:
+
+```bash
+nix run .#nvim-full
+```
+
+## Configuration Profiles
+
+### Full Profile
+
+Includes comprehensive language support and plugins:
+
+```bash
+nix run .#nvim-full
+```
+
+### Lite Profile
+
+A minimal configuration without language-specific plugins:
+
+```bash
+nix run .#nvim-lite
+```
+
+## Docker Images
+
+Run your configuration in Docker:
+
+```bash
+# Build the full Docker image
+nix build .#docker-full
+
+# Build the lite Docker image
+nix build .#docker-lite
+```
+
+## Customization
+
+### Adding New Plugins
+
+1. Create a new `.nix` file in the `config/` directory
+2. Add your plugin configuration
+3. The file will be automatically imported
+
+### Modifying Language Support
+
+Edit `full.nix` or `lite.nix` to enable/disable specific language support:
+
+```nix
+{
+  imports = [./config];
+
+  coldsteel = {
+    go = true;        # Go support
+    docker = true;    # Docker support
+    terraform = true; # Terraform support
+    web = true;       # Web development support
+    rust = true;      # Rust support
+    none-ls = true;   # None-LS support
+  };
+}
+```
+
+## Testing
+
+Verify your configuration:
+
+```bash
+nix flake check .
+```
+
+## Repository Structure
+
+```
+.
+├── config/                  # Main configuration directory
+│   ├── autopairs.nix        # Auto-pairs plugin configuration
+│   ├── bufferline.nix       # Buffer line plugin configuration
+│   ├── colors.nix           # Color scheme configuration
+│   ├── default.nix          # Main configuration entry point
+│   ├── keymappings.nix      # Keyboard mappings
+│   ├── lsp.nix              # Language Server Protocol configuration
+│   ├── lualine.nix          # Status line configuration
+│   ├── none-ls.nix          # None-LS (null-ls) configuration
+│   ├── oil.nix              # Oil.nvim file explorer configuration
+│   ├── options.nix          # Neovim options
+│   ├── telescope.nix        # Telescope fuzzy finder configuration
+│   └── treesitter.nix       # Treesitter configuration
+├── flake.nix                # Nix flake configuration
+├── full.nix                 # Full configuration profile
+├── lite.nix                 # Lite configuration profile
+├── module.nix               # Custom module options
+└── README.md                # Documentation
+```
+
+## Core Plugins
+
+Always enabled in both configurations:
+
+- `indent-blankline`: Indentation guides
+- `illuminate`: Highlights other uses of the word under cursor
+- `rainbow-delimiters`: Colorizes nested parentheses and brackets
+- `web-devicons`: File icons
+
+## Advanced Configuration
+
+For more advanced configuration:
+
+1. Modify `module.nix` to add new options
+2. Edit `flake.nix` to change dependencies or add packages
+3. Create new configuration profiles
+
+## Cachix Integration
+
+This repository uses Cachix for faster builds:
+
+```
+extra-substituters = [
+  "https://nix-community.cachix.org"
+  "https://andoriyu-nixvim.cachix.org"
+]
+```
+
+## GitHub Actions
+
+Automated testing across platforms:
+- x86_64-linux
+- aarch64-darwin
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is open source and available under the [MIT License](LICENSE).

--- a/config/lsp.nix
+++ b/config/lsp.nix
@@ -4,7 +4,7 @@
   ...
 }: {
   plugins.lsp = let
-    cfg = config.coldsteel;
+    cfg = config.coldsteel.nixvim;
   in {
     enable = true;
     servers = {
@@ -93,7 +93,7 @@
 
   plugins.cmp-path = {enable = true;};
 
-  plugins.rustaceanvim = {enable = config.coldsteel.rust;};
+  plugins.rustaceanvim = {enable = config.coldsteel.nixvim.rust;};
 
   keymaps = [
     {

--- a/config/none-ls.nix
+++ b/config/none-ls.nix
@@ -1,6 +1,6 @@
 {config, ...}: {
   config.plugins.none-ls = {
-    enable = config.coldsteel.none-ls;
+    enable = config.coldsteel.nixvim.none-ls;
     sources = {
       code_actions = {
         statix.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -1,50 +1,15 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -61,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -79,89 +44,16 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "nixvim",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730490306,
-        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
         "type": "github"
       }
     },
@@ -179,38 +71,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1729544999,
-        "narHash": "sha256-YcyJLvTmN6uLEBGCvYoMLwsinblXMkoYkNLEO4WnKus=",
+        "lastModified": 1737371634,
+        "narHash": "sha256-fTVAWzT1UMm1lT+YxHuVPtH+DATrhYfea3B0MxG/cGw=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "65c207c92befec93e22086da9456d3906a4e999c",
+        "rev": "a1176e2a10ce745ff8f63e4af124ece8fe0b1648",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.5",
+        "ref": "v0.0.7",
         "repo": "ixx",
-        "type": "github"
-      }
-    },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730448474,
-        "narHash": "sha256-qE/cYKBhzxHMtKtLK3hlSR3uzO1pWPGLrBuQK7r0CHc=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "683d0c4cd1102dcccfa3f835565378c7f3cbe05e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "repo": "nix-darwin",
         "type": "github"
       }
     },
@@ -221,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729742964,
-        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
         "type": "github"
       },
       "original": {
@@ -236,11 +107,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
         "type": "github"
       },
       "original": {
@@ -252,50 +123,47 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1746061036,
+        "narHash": "sha256-OxYwCGJf9VJ2KnUO+w/hVJVTjOgscdDg/lPv8Eus07Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "3afd19146cac33ed242fc0fc87481c67c758a59e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixvim": {
       "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
-        "git-hooks": "git-hooks",
-        "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
-        "nuschtosSearch": "nuschtosSearch",
-        "treefmt-nix": "treefmt-nix"
+        "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1730569492,
-        "narHash": "sha256-NByr7l7JetL9kIrdCOcRqBu+lAkruYXETp1DMiDHNQs=",
+        "lastModified": 1746138649,
+        "narHash": "sha256-mLtPx5Zb6b3iMmypaYsxzA8vjiI6DQObpbmGcn5QDjo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f210158b03b01a1fd44bf3968165e6da80635ce",
+        "rev": "0ec7ea3d6242de84c8a18b228b963064751cb56d",
         "type": "github"
       },
       "original": {
@@ -314,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730515563,
-        "narHash": "sha256-8lklUZRV7nwkPLF3roxzi4C2oyLydDXyAzAnDvjkOms=",
+        "lastModified": 1745046075,
+        "narHash": "sha256-8v4y6k16Ra/fiecb4DxhsoOGtzLKgKlS+9/XJ9z0T2I=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "9e22bd742480916ff5d0ab20ca2522eaa3fa061e",
+        "rev": "066afe8643274470f4a294442aadd988356a478f",
         "type": "github"
       },
       "original": {
@@ -347,27 +215,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730321837,
-        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -57,6 +57,26 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746134275,
+        "narHash": "sha256-sxfY7TIP59o2hcueanoRAtg833PiNroZkQDwlKJxGvs=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "015f1913109d44c36e683b55f0e47e283b383caa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "ixx": {
       "inputs": {
         "flake-utils": [
@@ -198,6 +218,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "home-manager": "home-manager",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim"

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nix-github-actions.url = "github:nix-community/nix-github-actions";
     nix-github-actions.inputs.nixpkgs.follows = "nixpkgs";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
@@ -24,6 +28,7 @@
     nixpkgs,
     flake-parts,
     nix-github-actions,
+    home-manager,
     ...
   } @ inputs:
     flake-parts.lib.mkFlake {inherit inputs;} {
@@ -34,8 +39,44 @@
       ];
 
       flake = {
+        # Home Manager module
+        homeManagerModules.default = { config, lib, pkgs, ... }: 
+          let 
+            # Import the module directly with the nixvim input
+            module = import ./home-manager-module.nix { 
+              inherit pkgs config lib;
+              nixvim = inputs.nixvim;
+            };
+          in module;
+        
+        # NixOS module
+        nixosModules.default = { config, pkgs, lib, ... }: {
+          imports = [ self.homeManagerModules.default ];
+        };
+        
+        # Library functions that can be used by consumers of this flake
+        lib = {
+          # Function to build a custom nixvim configuration
+          mkNixvim = { system, go ? false, docker ? false, terraform ? false, web ? false, rust ? false, none-ls ? false }:
+            let
+              pkgs = nixpkgs.legacyPackages.${system};
+              nixvim' = nixvim.legacyPackages.${system};
+            in
+              nixvim'.makeNixvimWithModule {
+                inherit pkgs;
+                module = {
+                  imports = [ ./config ];
+                  coldsteel.nixvim = {
+                    inherit go docker terraform web rust;
+                    "none-ls" = none-ls;
+                  };
+                };
+              };
+        };
+        
+        # GitHub Actions
         githubActions = nix-github-actions.lib.mkGithubMatrix {
-          checks = nixpkgs.lib.getAttrs ["x86_64-linux" "aarch64-darwin"] self.packages;
+          checks = nixpkgs.lib.getAttrs ["x86_64-linux" "aarch64-darwin"] self.checks;
         };
       };
 
@@ -46,21 +87,21 @@
       }: let
         nixvimLib = nixvim.lib.${system};
         nixvim' = nixvim.legacyPackages.${system};
+          
         nixvimModuleFull = {
           inherit pkgs;
           module = import ./full.nix; # import the module directly
-          # You can use `extraSpecialArgs` to pass additional arguments to your module files
-          extraSpecialArgs = {
-          };
+          extraSpecialArgs = {};
         };
+        
         nvimFull = nixvim'.makeNixvimWithModule nixvimModuleFull;
+        
         nixvimModuleLite = {
           inherit pkgs;
           module = import ./lite.nix; # import the module directly
-          # You can use `extraSpecialArgs` to pass additional arguments to your module files
-          extraSpecialArgs = {
-          };
+          extraSpecialArgs = {};
         };
+        
         nvimLite = nixvim'.makeNixvimWithModule nixvimModuleLite;
       in {
         _module.args.pkgs = import inputs.nixpkgs {
@@ -71,6 +112,8 @@
         checks = {
           # Run `nix flake check .` to verify that your config is not broken
           default = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModuleFull;
+          nvim-lite = nvimLite;
+          nvim-full = nvimFull;
         };
 
         packages = {
@@ -78,6 +121,7 @@
           default = nvimLite;
           nvim-lite = nvimLite;
           nvim-full = nvimFull;
+          
           docker-full = pkgs.dockerTools.buildImage {
             name = "nvim";
             tag = "full";

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,14 @@
           default = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModuleFull;
           nvim-lite = nvimLite;
           nvim-full = nvimFull;
+          
+          # Test the home-manager module
+          home-manager-module = import ./tests/home-manager-module-test.nix {
+            inherit pkgs;
+            lib = nixpkgs.lib;
+            nixvimMock = import ./tests/nixvim-mock.nix { inherit pkgs system; };
+            hmLib = inputs.home-manager.lib;
+          };
         };
 
         packages = {

--- a/full.nix
+++ b/full.nix
@@ -1,7 +1,7 @@
 {
   imports = [./config];
 
-  coldsteel = {
+  coldsteel.nixvim = {
     go = true;
     docker = true;
     terraform = true;

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  pkgs,
+  config,
+  nixvim,
+  ...
+}: 
+with lib;
+let
+  cfg = config.coldsteel.nixvim;
+  
+  # Function to build nixvim with the specified options
+  buildNixvim = { go ? false, docker ? false, terraform ? false, web ? false, rust ? false, none-ls ? false }:
+    nixvim.legacyPackages.${pkgs.system}.makeNixvimWithModule {
+      inherit pkgs;
+      module = {
+        imports = [ ./config ];
+        coldsteel.nixvim = {
+          inherit go docker terraform web rust;
+          "none-ls" = none-ls;
+        };
+      };
+    };
+in {
+  options.coldsteel.nixvim = {
+    enable = mkEnableOption "Enable coldsteel nixvim configuration";
+    
+    defaultEditor = mkOption {
+      type = types.bool;
+      description = "Whether to set nixvim as the default editor";
+      default = false;
+    };
+    
+    # Re-export the options from module.nix
+    go = mkEnableOption "plugin support for Go Lang";
+    docker = mkEnableOption "plugin support for Dockerfiles";
+    terraform = mkEnableOption "plugin support for Terraform";
+    web = mkEnableOption "plugin support for Web Development";
+    rust = mkEnableOption "plugin support for Rust";
+    none-ls = mkEnableOption "none-ls plugin";
+    
+    # Preset configurations
+    preset = mkOption {
+      type = types.enum [ "none" "lite" "full" "custom" ];
+      default = "custom";
+      description = ''
+        Preset configuration to use:
+        - none: No language support
+        - lite: Minimal configuration without language-specific plugins
+        - full: Full configuration with all language support
+        - custom: Use the individual options (go, docker, etc.)
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Build a custom nixvim package based on the preset or custom options
+    home.packages = let
+      nvimPackage = 
+        if cfg.preset == "lite" then
+          nixvim.legacyPackages.${pkgs.system}.makeNixvimWithModule {
+            inherit pkgs;
+            module = import ./lite.nix;
+          }
+        else if cfg.preset == "full" then
+          nixvim.legacyPackages.${pkgs.system}.makeNixvimWithModule {
+            inherit pkgs;
+            module = import ./full.nix;
+          }
+        else if cfg.preset == "none" then
+          buildNixvim {
+            go = false;
+            docker = false;
+            terraform = false;
+            web = false;
+            rust = false;
+            none-ls = false;
+          }
+        else
+          # Custom configuration
+          buildNixvim {
+            inherit (cfg) go docker terraform web rust;
+            none-ls = cfg.none-ls;
+          };
+    in [ nvimPackage ];
+    
+    # Set as default editor if requested
+    programs.bash.shellAliases = mkIf cfg.defaultEditor {
+      vi = "nvim";
+      vim = "nvim";
+    };
+    
+    home.sessionVariables = mkIf cfg.defaultEditor {
+      EDITOR = "nvim";
+      VISUAL = "nvim";
+    };
+  };
+}

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -37,7 +37,7 @@ in {
     terraform = mkEnableOption "plugin support for Terraform";
     web = mkEnableOption "plugin support for Web Development";
     rust = mkEnableOption "plugin support for Rust";
-    none-ls = mkEnableOption "none-ls plugin";
+    "none-ls" = mkEnableOption "none-ls plugin";
     
     # Preset configurations
     preset = mkOption {
@@ -74,13 +74,13 @@ in {
             terraform = false;
             web = false;
             rust = false;
-            none-ls = false;
+            "none-ls" = false;
           }
         else
           # Custom configuration
           buildNixvim {
             inherit (cfg) go docker terraform web rust;
-            none-ls = cfg.none-ls;
+            "none-ls" = cfg."none-ls";
           };
     in [ nvimPackage ];
     

--- a/lite.nix
+++ b/lite.nix
@@ -1,7 +1,7 @@
 {
   imports = [./config];
 
-  coldsteel = {
+  coldsteel.nixvim = {
     go = false;
     docker = false;
     terraform = false;

--- a/module.nix
+++ b/module.nix
@@ -1,6 +1,6 @@
 {lib, ...}: {
   options = {
-    coldsteel = {
+    coldsteel.nixvim = {
       go = lib.mkEnableOption {
         description = "Enables plugin support for Go Lang";
       };

--- a/tests/eval-home-module.nix
+++ b/tests/eval-home-module.nix
@@ -1,0 +1,28 @@
+{ pkgs
+, lib
+, nixvimMock          # import ./nixvim-mock.nix { pkgs = pkgs; system = pkgs.system; }
+, hmLib               # home-manager.lib passed by flake.nix
+}:
+
+let
+  baseModule = { ... }: {
+    # absolute minimum every HM config needs
+    home.username      = "tester";
+    home.homeDirectory = "/homeless-shelter";
+    home.stateVersion  = "23.11";
+  };
+
+  eval = extraConfig:
+    (hmLib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        baseModule
+        ../home-manager-module.nix          # the module under test
+        ({ ... }: extraConfig)              # per-test overrides
+      ];
+      extraSpecialArgs = {
+        nixvim = nixvimMock;   # expose the mock as the normal "nixvim" arg
+      };
+    }).config;                              # ← what we assert against
+in
+eval

--- a/tests/home-manager-module-test.nix
+++ b/tests/home-manager-module-test.nix
@@ -1,0 +1,67 @@
+{ pkgs, lib, nixvimMock, hmLib }:
+
+let
+  eval = import ./eval-home-module.nix { inherit pkgs lib nixvimMock hmLib; };
+
+  cases = [
+    {
+      name   = "basic-enable";
+      config = { coldsteel.nixvim.enable = true; };
+      check  = cfg: 
+        let
+          isMock = p: lib.hasInfix "mock-nixvim" (toString p);
+          cnt    = builtins.length (builtins.filter isMock cfg.home.packages);
+        in lib.assertMsg
+             (cnt == 1)
+             "expected exactly one mock-nixvim package, found ${toString cnt}";
+    }
+    {
+      name   = "with-go-rust";
+      config = {
+        coldsteel.nixvim = { enable = true; go = true; rust = true; };
+      };
+      check  = cfg:
+        let
+          isMock = p: lib.hasInfix "mock-nixvim" (toString p);
+          cnt    = builtins.length (builtins.filter isMock cfg.home.packages);
+        in lib.assertMsg
+             (cnt == 1)
+             "expected exactly one mock-nixvim package, found ${toString cnt}";
+    }
+    {
+      name   = "default-editor";
+      config = { coldsteel.nixvim = { enable = true; defaultEditor = true; }; };
+      check  = cfg:
+        cfg.home.sessionVariables.EDITOR == "nvim"
+        && cfg.programs.bash.shellAliases.vim == "nvim";
+    }
+    {
+      name   = "preset-full";
+      config = { coldsteel.nixvim = { enable = true; preset = "full"; }; };
+      check  = cfg:
+        let
+          isMock = p: lib.hasInfix "mock-nixvim" (toString p);
+          cnt    = builtins.length (builtins.filter isMock cfg.home.packages);
+        in lib.assertMsg
+             (cnt == 1)
+             "expected exactly one mock-nixvim package, found ${toString cnt}";
+    }
+  ];
+
+  results = builtins.map (c:
+    let cfg = eval c.config;
+    in { name = c.name; passed = c.check cfg; })
+    cases;
+
+  allPassed = builtins.all (r: r.passed) results;
+
+  report = builtins.concatStringsSep "\n"
+    (map (r: "Test ${r.name}: ${if r.passed then "PASSED" else "FAILED"}")
+     results);
+in
+pkgs.runCommand "hm-module-tests"
+  { passthru.tests = results; inherit allPassed; }
+  ''
+    echo "${report}" > $out
+    ${lib.optionalString (!allPassed) "exit 1"}
+  ''

--- a/tests/nixvim-mock.nix
+++ b/tests/nixvim-mock.nix
@@ -1,0 +1,17 @@
+{ pkgs, system }:
+
+let
+  makeNvim = { module, ... }:
+    # A dummy derivation that pretends to be an nvim package
+    pkgs.runCommand "mock-nixvim-${system}" {} ''
+      mkdir -p $out/bin
+      cat > $out/bin/nvim <<'EOF'
+      #!${pkgs.runtimeShell}
+      echo "Mock Nixvim – enabled features: ${builtins.toJSON module.coldsteel.nixvim or {}}"
+      EOF
+      chmod +x $out/bin/nvim
+    '';
+in
+{
+  legacyPackages.${system}.makeNixvimWithModule = makeNvim;
+}


### PR DESCRIPTION
This PR adds a home-manager module and a library function for building custom nixvim configurations.

## Changes

- Added home-manager module with support for:
  - Enabling/disabling specific language support
  - Preset configurations (none, lite, full, custom)
  - Setting nixvim as the default editor

- Added lib.mkNixvim function for building custom configurations
- Updated namespace from 'coldsteel' to 'coldsteel.nixvim'
- Updated documentation with usage examples
- Updated flake inputs to latest versions

## Usage

### Home Manager Integration

```nix
{
  inputs.coldsteel-nixvim.url = "github:andoriyu/nixvim";
  
  outputs = { self, nixpkgs, home-manager, coldsteel-nixvim, ... }: {
    homeConfigurations."username" = home-manager.lib.homeManagerConfiguration {
      # ...
      modules = [
        coldsteel-nixvim.homeManagerModules.default
        {
          coldsteel.nixvim = {
            enable = true;
            defaultEditor = true;
            go = true;
            rust = true;
          };
        }
      ];
    };
  };
}
```

### Using the Library Function

```nix
{
  environment.systemPackages = [
    (inputs.coldsteel-nixvim.lib.mkNixvim {
      system = pkgs.system;
      go = true;
      rust = true;
    })
  ];
}
```
